### PR TITLE
Fix/rails 6.1 resolution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.4
 
+Style/Documentation:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.7"
+group :development, :test do
+  gem "rspec", "~> 3.0"
+  gem "rubocop", "~> 1.7"
+  gem "rubocop-rake", "~> 0.5.1"
+  gem "rubocop-rspec", "~> 2.3"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,16 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-19
 
 DEPENDENCIES
@@ -50,6 +56,8 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.7)
+  rubocop-rake (~> 0.5.1)
+  rubocop-rspec (~> 2.3)
 
 BUNDLED WITH
-   2.2.14
+   2.2.17

--- a/katalyst-basic-auth.gemspec
+++ b/katalyst-basic-auth.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   # spec.description   = "Gem to add basic auth on staging websites"
   spec.homepage      = "https://github.com/katalyst/katalyst-basic-auth"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.8")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["allowed_push_host"] = "https://github.com"
 

--- a/lib/katalyst/basic/auth/config.rb
+++ b/lib/katalyst/basic/auth/config.rb
@@ -33,7 +33,13 @@ module Katalyst
           end
 
           def default_username
-            rails? ? Rails.application.class.parent_name.underscore : "katalyst"
+            return "katalyst" unless rails?
+
+            if Rails::VERSION::MAJOR >= 6
+              Rails.application.class.module_parent_name.underscore
+            else
+              Rails.application.class.parent_name.underscore
+            end
           end
 
           def default_password

--- a/spec/katalyst/basic/config_spec.rb
+++ b/spec/katalyst/basic/config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Katalyst::Basic::Auth::Config do
+RSpec.describe Katalyst::Basic::Auth::Config do # rubocop:disable Metrics/BlockLength
   subject { described_class }
 
   def with_environment(name, value)


### PR DESCRIPTION
Resolve using `module_parent_name` instead of the deprecated `parent_name` when Rails 6.x.

Also has some RuboCop and security updates which can be moved to a separate PR if needed.