### PR TITLE
Add multiple path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The gem provides a rake task that can be used to query basic auth settings:
 
     $ rake katalyst_basic_auth:info  
 
+Additional paths can be password protected by adding configuration to an initializer. e.g.
+
+    Katalyst::Basic::Auth.add("/secure-path", username: "user", password: "pass") if Rails.env.production?
+
+The username and password parameters are optional. Use the rake task to find the default settings.
+
+Paths can also be excluded from basic auth. e.g. to allow access to `/public` without basic authentication:
+
+    Katalyst::Basic::Auth.exclude("/public")
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/katalyst/basic/auth.rb
+++ b/lib/katalyst/basic/auth.rb
@@ -4,3 +4,21 @@ require_relative "auth/version"
 require_relative "auth/config"
 require_relative "auth/middleware"
 require_relative "auth/rails" if defined?(Rails)
+
+module Katalyst
+  module Basic
+    module Auth
+      class << self
+        # Add a path to be protected by basic authentication
+        def add(path, username: nil, password: nil)
+          Config.add(path: path, username: username, password: password)
+        end
+
+        # Add a path to be excluded from basic authentication
+        def exclude(path)
+          Config.add(path: path, enabled: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/katalyst/basic/auth/config.rb
+++ b/lib/katalyst/basic/auth/config.rb
@@ -6,21 +6,61 @@ module Katalyst
   module Basic
     module Auth
       class Config
+        DEFAULT_USERNAME = "katalyst"
+        ROOT_PATH        = "/"
+
         class << self
+          include Enumerable
+
+          # @param path [String] Request path
+          # @return [Config] The config for the given path
+          def for_path(path)
+            path ||= ROOT_PATH
+            all.sort_by(&:path)
+               .reverse
+               .detect { |i| path.match(/^#{i.path}/) } || global
+          end
+
+          # @return [Config] The global configuration
+          def global
+            all[0]
+          end
+
+          def add(path:, username: nil, password: nil, enabled: nil)
+            config = new(path: path, username: username, password: password, enabled: enabled)
+            all.delete(all.detect { |i| i.path == config.path })
+            all << config
+            config
+          end
+
+          def all
+            @all ||= [new]
+          end
+
+          def reset!
+            @all = [new]
+          end
+
+          def each(&block)
+            all.each(&block)
+          end
+
+          def description
+            output = ["Basic auth settings:", ""]
+            all.each do |config|
+              output << "path:     #{config.root_path? ? "(global)" : config.path}"
+              output << "enabled:  #{config.enabled?}"
+              output << "username: #{config.username}"
+              output << "password: #{config.password}"
+              output << ""
+            end
+            output.join("\n")
+          end
+
           def enabled?
-            enable = ENV.fetch("KATALYST_BASIC_AUTH_ENABLED", enabled_rails_env?)
-            [true, "yes", "true"].include?(enable)
+            global_enabled = ENV.fetch("KATALYST_BASIC_AUTH_ENABLED", enabled_rails_env?)
+            [true, "yes", "true"].include?(global_enabled)
           end
-
-          def username
-            ENV["KATALYST_BASIC_AUTH_USER"] || default_username
-          end
-
-          def password
-            ENV["KATALYST_BASIC_AUTH_PASS"] || default_password
-          end
-
-          private
 
           def enabled_rails_env?
             return false unless rails?
@@ -33,7 +73,8 @@ module Katalyst
           end
 
           def default_username
-            return "katalyst" unless rails?
+            return ENV["KATALYST_BASIC_AUTH_USER"] if ENV["KATALYST_BASIC_AUTH_USER"]
+            return DEFAULT_USERNAME unless rails?
 
             if Rails::VERSION::MAJOR >= 6
               Rails.application.class.module_parent_name.underscore
@@ -42,8 +83,10 @@ module Katalyst
             end
           end
 
-          def default_password
-            Digest::SHA256.hexdigest("#{default_password_salt}#{default_username}")[0..15]
+          def default_password(username)
+            return ENV["KATALYST_BASIC_AUTH_PASS"] if ENV["KATALYST_BASIC_AUTH_PASS"]
+
+            Digest::SHA256.hexdigest("#{default_password_salt}#{username}")[0..15]
           end
 
           def default_password_salt
@@ -53,6 +96,32 @@ module Katalyst
               ENV["SECRET_KEY_BASE"]
             end
           end
+        end
+
+        attr_reader :path, :username, :password
+
+        def enabled?
+          @enabled
+        end
+
+        def root_path?
+          path == ROOT_PATH
+        end
+
+        private
+
+        def initialize(path: nil, username: nil, password: nil, enabled: nil)
+          @path     = sanitize_path(path)
+          @username = username || self.class.default_username
+          @password = password || self.class.default_password(@username)
+          @enabled  = enabled.nil? ? (!root_path? || self.class.enabled?) : enabled
+        end
+
+        def sanitize_path(path)
+          return ROOT_PATH if path.nil?
+
+          path = "/#{path}" unless path.start_with?("/")
+          path
         end
       end
     end

--- a/lib/katalyst/basic/auth/middleware.rb
+++ b/lib/katalyst/basic/auth/middleware.rb
@@ -11,8 +11,11 @@ module Katalyst
         end
 
         def call(env)
+          config = Config.for_path(env["PATH_INFO"])
+          return @app.call(env) unless config.enabled?
+
           auth = Rack::Auth::Basic.new(app) do |u, p|
-            u == Config.username && p == Config.password
+            u == config.username && p == config.password
           end
           auth.call env
         end

--- a/lib/katalyst/basic/auth/rails.rb
+++ b/lib/katalyst/basic/auth/rails.rb
@@ -6,12 +6,10 @@ module Katalyst
       class Railtie < Rails::Railtie
         initializer "katalyst.basic.auth.configure_rack_middleware" do |app|
           middleware = Katalyst::Basic::Auth::Middleware
-          if Config.enabled?
-            if Rails::VERSION::MAJOR >= 4
-              app.middleware.insert_before Rack::Sendfile, middleware
-            else
-              app.config.app_middleware.use middleware
-            end
+          if Rails::VERSION::MAJOR >= 4
+            app.middleware.insert_before Rack::Sendfile, middleware
+          else
+            app.config.app_middleware.use middleware
           end
         end
 

--- a/lib/katalyst/basic/auth/tasks/auth.rake
+++ b/lib/katalyst/basic/auth/tasks/auth.rake
@@ -2,11 +2,7 @@
 
 namespace :katalyst_basic_auth do
   desc "Display basic auth information for the app"
-  task :info do
-    config = Katalyst::Basic::Auth::Config
-    puts "Basic auth settings:"
-    puts "enabled: #{config.enabled?}"
-    puts "username: #{config.username}"
-    puts "password: #{config.password}"
+  task info: :environment do
+    puts Katalyst::Basic::Auth::Config.description
   end
 end

--- a/spec/katalyst/basic/config_spec.rb
+++ b/spec/katalyst/basic/config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Katalyst::Basic::Auth::Config do # rubocop:disable Metrics/BlockLength
-  subject { described_class }
+  subject { described_class.new }
 
   def with_environment(name, value)
     orig      = ENV[name]
@@ -46,8 +46,8 @@ RSpec.describe Katalyst::Basic::Auth::Config do # rubocop:disable Metrics/BlockL
     let(:rails_env) { "development" }
 
     around(:each) do |example|
-      rails = Object.const_set("Rails", Class.new)
-      env   = DummyRailsEnv.new
+      rails     = Object.const_set("Rails", DummyRails)
+      env       = DummyRailsEnv.new
       env.value = rails_env
       rails.define_singleton_method(:env) { env }
 
@@ -91,6 +91,29 @@ RSpec.describe Katalyst::Basic::Auth::Config do # rubocop:disable Metrics/BlockL
 
     it "is not enabled" do
       expect(subject.enabled?).to be_falsey
+    end
+  end
+
+  describe "#description" do
+    it "describes basic auth configuration" do
+      expect(described_class.description).to be_kind_of(String)
+    end
+  end
+
+  describe "#for_path" do
+    let!(:config1) { described_class.add(path: "/path1", username: "user1") }
+    let!(:config2) { described_class.add(path: "/path2", username: "user2") }
+
+    it "matches path 1" do
+      expect(described_class.for_path("/path1/foo/bar.html")).to eq(config1)
+    end
+
+    it "matches path 2" do
+      expect(described_class.for_path("/path2/foo/bar.html")).to eq(config2)
+    end
+
+    it "matches the global config" do
+      expect(described_class.for_path("/path3/foo/bar.html")).to eq(described_class.global)
     end
   end
 end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -11,3 +11,31 @@ class DummyRailsEnv
     end
   end
 end
+
+class DummyRails
+  module VERSION
+    MAJOR = 4
+  end
+
+  class Application
+    class << self
+      def module_parent_name
+        self
+      end
+
+      def parent_name
+        self
+      end
+
+      def underscore
+        "app"
+      end
+    end
+  end
+
+  class << self
+    def application
+      Application.new
+    end
+  end
+end


### PR DESCRIPTION
Additional paths can be password protected by adding configuration to an initializer. e.g.

    Katalyst::Basic::Auth.add("/secure-path", username: "user", password: "pass") if Rails.env.production?

paths can also be excluded from basic auth, e.g.

    Katalyst::Basic::Auth.exclude("/public-path")
